### PR TITLE
Add method to show field

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ there's multiple ways to render trix for already existing model
 {!! app('laravel-trix')->make($post, 'content') !!}
 ```
 
+### Render Html For Existing Model
+
+You can render the html content for already existing model
+
+```php
+<!-- inside view blade file -->
+
+{!! $post->trixRender('content') !!} //must use HasTrixRichText trait in order for $model->trixRender() method work
+```
 
 ### Storing Attachment
 

--- a/src/Traits/HasTrixRichText.php
+++ b/src/Traits/HasTrixRichText.php
@@ -64,4 +64,9 @@ trait HasTrixRichText
     {
         return $this->morphMany(TrixAttachment::class, 'attachable');
     }
+
+    public function trixRender($field)
+    {
+        return $this->trixRichText->where('field', $field)->first()->content;
+    }
 }

--- a/tests/Feature/HasTrixRichTextTest.php
+++ b/tests/Feature/HasTrixRichTextTest.php
@@ -58,4 +58,16 @@ class HasTrixRichTextTest extends TestCase
 
         $this->assertFalse((bool) TrixAttachment::first()->is_pending);
     }
+
+    /** @test */
+    public function it_renders_the_content()
+    {
+        $post = Post::create([
+            'post-trixFields' => [
+                'content' => $expected = '<h1>foo</h1>',
+            ],
+        ]);
+
+        $this->assertEquals($expected, $post->trixRender('content'));
+    }
 }


### PR DESCRIPTION

This PR will add a `trixRender($field)` to the `HasTrixRichText` trait.

This will make it easier to render the content of a field, without the trix editor, when we just want to show the content and not edit it.

This is a direct implementation of this suggestion: https://github.com/amaelftah/laravel-trix/issues/28#issuecomment-596494447